### PR TITLE
Added support for compiling against different kernel. Check for NDPI_PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 all:
+ifeq ($(strip $(NDPI_PATH)),)
+	$(error NDPI_PATH required)
+endif
 	$(MAKE) -C ipt
 	$(MAKE) -C src
 modules_install:

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@ NDPI_PRO := ${NDPI_SRC}/lib/protocols
 ccflags-y += -I${src}/${NDPI_SRC}/include -I${src}/${NDPI_SRC}/lib -DOPENDPI_NETFILTER_MODULE -DNDPI_IPTABLES_EXT
 
 MODULES_DIR := /lib/modules/$(shell uname -r)
-KERNEL_DIR := ${MODULES_DIR}/build
+KERNEL_DIR ?= ${MODULES_DIR}/build
 
 obj-m := xt_ndpi.o
 xt_ndpi-y := main.o \


### PR DESCRIPTION
Added sanity check for NDPI_PATH before compiling

Allowed KERNEL_DIR to be overridden to facilitate compiling against a different kernel.